### PR TITLE
Fixed fps cap

### DIFF
--- a/src/components/world.js
+++ b/src/components/world.js
@@ -65,14 +65,14 @@ define([
     World.prototype.begin = function(selection){
         selection[0][0].appendChild(this.renderer.domElement);
         var world = this;
-        var interval = 1000/30;
+        var minInterval = 1000/30;
         var before = Date.now();
 
         this.animate = function(){
             window.requestAnimationFrame(world.animate);
             var now = Date.now();
-            if(now - before > interval){
-                before = now;
+            if(now - before > minInterval){
+                before += minInterval;
                 world.renderer.render(world.scene, world.camera);
                 world.controls.update();
             }


### PR DESCRIPTION
The FPS cap in World.animate is a bit off. The real frame rate will always be lower than the given interval, because the `before` is wrongly updated. It needs to be set to `now - (now-before - interval)` which is just `before += interval`

Also changed name interval to minInterval, because its only a cap. Actual interval can be longer (readability).
